### PR TITLE
fix:  fixed issue with axisSync never not working

### DIFF
--- a/public/ThirdPersonMouseDragControls/index.html
+++ b/public/ThirdPersonMouseDragControls/index.html
@@ -139,6 +139,7 @@
 
         // GUI - Camera
         const folder4 = gui.addFolder('Camera');
+        folder4.add(controls, 'axisSync', ['always', 'move', 'never']);
         const cameraPosition = folder4.addFolder('Position');
         cameraPosition.add(controls.cameraPosOffset, 'x', -10, 10).name('x').listen();
         cameraPosition.add(controls.cameraPosOffset, 'y', -10, 10).name('y').listen();

--- a/public/ThirdPersonPointerLockControls/index.html
+++ b/public/ThirdPersonPointerLockControls/index.html
@@ -139,6 +139,7 @@
 
         // GUI - Camera
         const folder4 = gui.addFolder('Camera');
+        folder4.add(controls, 'axisSync', ['always', 'move', 'never']);
         const cameraPosition = folder4.addFolder('Position');
         cameraPosition.add(controls.cameraPosOffset, 'x', -10, 10).name('x').listen();
         cameraPosition.add(controls.cameraPosOffset, 'y', -10, 10).name('y').listen();

--- a/src/controls/ThirdPersonMouseDragControls.ts
+++ b/src/controls/ThirdPersonMouseDragControls.ts
@@ -72,6 +72,7 @@ class ThirdPersonMouseDragControls extends PhysicsCharacterControls {
   private _accumulatedDirection: Vector3 = new Vector3();
   private _cameraLookAtPosition: Vector3 = new Vector3();
   private _cameraLerpPosition: Vector3 = new Vector3();
+  private _forwardDirection: Vector3 = new Vector3();
 
   // Handlers for keyboard events.
   private onKeyDownHandler: (event: KeyboardEvent) => void;
@@ -162,7 +163,7 @@ class ThirdPersonMouseDragControls extends PhysicsCharacterControls {
    * @returns Normalized forward vector.
    */
   private getForwardVector(): Vector3 {
-    this.camera.getWorldDirection(this._objectWorldDirection);
+    this._objectWorldDirection.copy(this._forwardDirection);
     this._objectWorldDirection.y = 0;
     this._objectWorldDirection.normalize();
     return this._objectWorldDirection;
@@ -173,7 +174,7 @@ class ThirdPersonMouseDragControls extends PhysicsCharacterControls {
    * @returns Normalized side vector.
    */
   private getSideVector(): Vector3 {
-    this.camera.getWorldDirection(this._objectWorldDirection);
+    this._objectWorldDirection.copy(this._forwardDirection);
     this._objectWorldDirection.y = 0;
     this._objectWorldDirection.normalize();
     this._objectWorldDirection.cross(this.object.up);
@@ -182,6 +183,7 @@ class ThirdPersonMouseDragControls extends PhysicsCharacterControls {
 
   private updateSync() {
     if (this.axisSync === 'always') {
+      this.camera.getWorldDirection(this._forwardDirection);
       this.object.lookAt(this.object.position.clone().add(this.getForwardVector()));
       return;
     }
@@ -190,6 +192,7 @@ class ThirdPersonMouseDragControls extends PhysicsCharacterControls {
       this.axisSync === 'move' &&
       (keyStates.forward || keyStates.backward || keyStates.leftward || keyStates.rightward)
     ) {
+      this.camera.getWorldDirection(this._forwardDirection);
       this.object.lookAt(this.object.position.clone().add(this.getForwardVector()));
       return;
     }

--- a/src/controls/ThirdPersonPointerLockControls.ts
+++ b/src/controls/ThirdPersonPointerLockControls.ts
@@ -57,8 +57,6 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
 
   actionKeys: ActionKeys;
 
-  private _isMouseDown: boolean = false;
-
   // Physics options
   jumpForce: number;
   groundMoveSpeed: number;
@@ -69,6 +67,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
   private _objectWorldDirection: Vector3 = new Vector3();
   private _accumulatedDirection: Vector3 = new Vector3();
   private _cameraLookAtPosition: Vector3 = new Vector3();
+  private _forwardDirection: Vector3 = new Vector3();
 
   // Handlers for keyboard events.
   private onKeyDownHandler: (event: KeyboardEvent) => void;
@@ -107,6 +106,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
     this._spherical = new Spherical();
     this.updateCameraInfo();
 
+    this.object.getWorldDirection(this._forwardDirection);
     this.axisSync = cameraOptions.axisSync ?? 'move';
 
     // Set physics options with default values
@@ -156,7 +156,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
    * @returns Normalized forward vector.
    */
   private getForwardVector(): Vector3 {
-    this.camera.getWorldDirection(this._objectWorldDirection);
+    this._objectWorldDirection.copy(this._forwardDirection);
     this._objectWorldDirection.y = 0;
     this._objectWorldDirection.normalize();
     return this._objectWorldDirection;
@@ -167,7 +167,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
    * @returns Normalized side vector.
    */
   private getSideVector(): Vector3 {
-    this.camera.getWorldDirection(this._objectWorldDirection);
+    this._objectWorldDirection.copy(this._forwardDirection);
     this._objectWorldDirection.y = 0;
     this._objectWorldDirection.normalize();
     this._objectWorldDirection.cross(this.object.up);
@@ -176,6 +176,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
 
   private updateSync() {
     if (this.axisSync === 'always') {
+      this.camera.getWorldDirection(this._forwardDirection);
       this.object.lookAt(this.object.position.clone().add(this.getForwardVector()));
       return;
     }
@@ -184,6 +185,7 @@ class ThirdPersonPointerLockControls extends PhysicsCharacterControls {
       this.axisSync === 'move' &&
       (keyStates.forward || keyStates.backward || keyStates.leftward || keyStates.rightward)
     ) {
+      this.camera.getWorldDirection(this._forwardDirection);
       this.object.lookAt(this.object.position.clone().add(this.getForwardVector()));
       return;
     }


### PR DESCRIPTION
- Added a new field, `forwardDirections`, to the `ThirdPersonMouseDragControls`, `ThirdPersonPointerLockControls`.
- Initialized `forwardDirections` with the direction the object is facing.
- Update `forwardDirections` based on the sync type in `updateSync` method